### PR TITLE
Portable infoboxes stats

### DIFF
--- a/infoboxes-stats/README.md
+++ b/infoboxes-stats/README.md
@@ -4,3 +4,9 @@ infoboxes-stats
 Set of Python script that collect various statistics regarding the use of infoboxes parameters across articles and wikis.
 
 It uses Nirvana API provided by [Wikia/app#16470](https://github.com/Wikia/app/pull/16470) at `/api/v1/Templates/Metadata`.
+
+**Python 3.6+ is required**:
+
+```
+virtualenv env -ppython3
+```

--- a/infoboxes-stats/infoboxes_stats.py
+++ b/infoboxes-stats/infoboxes_stats.py
@@ -1,0 +1,105 @@
+"""
+Given a list of wikis emits statistics regarding shared templates, their parameters
+and value types
+"""
+from __future__ import print_function
+
+import logging
+
+from collections import Counter
+
+from mwclient.client import Site
+import requests
+
+logging.basicConfig(level=logging.INFO)
+
+
+# set up shared HTTP client
+pool = requests.Session()
+pool.proxies = {'http': 'border-http-s3:80'}
+
+
+def get_site(wiki_domain: str):
+    """
+    :type wiki_domain str
+    :rtype: Site
+    """
+    return Site(host=('http', wiki_domain), path='/', pool=pool)
+
+
+def get_querypage(site: Site, page: str):
+    """
+    :type site Site
+    :type page str
+    :rtype: list[str]
+    """
+    # http://poznan.wikia.com/api.php?action=query&list=querypage&qppage=Nonportableinfoboxes
+    # http://poznan.wikia.com/api.php?action=query&list=querypage&qppage=Mostlinkedtemplates
+    res = site.get(action='query', list='querypage', qppage=page, qplimit=500)
+    return [
+        # (u'value', u'69'), (u'ns', 10), (u'title', u'Template:Crew TV')
+        entry['title']
+        for entry in res['query']['querypage']['results']
+    ]
+
+
+def get_portable_infoboxes(wikis):
+    """
+    :type: wikis list[str]
+    :rtype: list[str]
+    """
+    logger = logging.getLogger('get_portable_infoboxes')
+
+    global_templates = Counter()
+
+    for wiki_domain in wikis:
+        site = get_site(wiki_domain)
+
+        logger.info('Processing <%s> wiki', site.host[1])
+
+        all_infoboxes = get_querypage(site, 'AllInfoboxes')
+        non_portable = get_querypage(site, 'Nonportableinfoboxes')
+        # print(all_infoboxes, non_portable)
+
+        logger.info('%s: %d infoboxes in total (%d of them are non-portable)',
+                    wiki_domain, len(all_infoboxes), len(non_portable))
+
+        # list only portable infoboxes
+        infoboxes = [
+            template
+            for template in all_infoboxes
+            if template not in non_portable
+        ]
+
+        # print(wiki_domain, infoboxes)
+
+        for infobox in infoboxes:
+            global_templates.update((infobox,))
+
+    logger.info('%d unique template', len(global_templates.keys()))
+    logger.info(global_templates.most_common(10))
+
+
+if __name__ == '__main__':
+    mapping = get_portable_infoboxes(
+        wikis="""
+villains.fandom.com
+walkingdead.fandom.com
+memory-alpha.fandom.com
+powerrangers.fandom.com
+steven-universe.fandom.com
+ttte.fandom.com
+spongebob.fandom.com
+supernatural.fandom.com
+muppet.fandom.com
+tardis.fandom.com
+vampirediaries.fandom.com
+hero.fandom.com
+        """.strip().split('\n')
+    )
+
+    """
+    for arg, items in mapping.items():
+        print('{} -> {}'.format(
+            arg, items))
+    """

--- a/infoboxes-stats/infoboxes_stats.py
+++ b/infoboxes-stats/infoboxes_stats.py
@@ -1,12 +1,17 @@
 """
 Given a list of wikis emits statistics regarding shared templates, their parameters
 and value types
+
+This script for each wiki:
+
+- takes 50 most used portable infoboxes
+- analyzes the names of template parameters
 """
 from __future__ import print_function
 
 import logging
 
-from collections import Counter
+from collections import Counter, defaultdict
 
 from mwclient.client import Site
 import requests
@@ -27,20 +32,42 @@ def get_site(wiki_domain: str):
     return Site(host=('http', wiki_domain), path='/', pool=pool)
 
 
-def get_querypage(site: Site, page: str):
+def get_querypage(site: Site, page: str, limit: int = 500):
     """
     :type site Site
     :type page str
+    :type limit int
     :rtype: list[str]
     """
     # http://poznan.wikia.com/api.php?action=query&list=querypage&qppage=Nonportableinfoboxes
     # http://poznan.wikia.com/api.php?action=query&list=querypage&qppage=Mostlinkedtemplates
-    res = site.get(action='query', list='querypage', qppage=page, qplimit=500)
+    # http://poznan.wikia.com/api.php?action=query&list=querypage&qppage=AllInfoboxes
+    res = site.get(action='query', list='querypage', qppage=page, qplimit=limit)
     return [
         # (u'value', u'69'), (u'ns', 10), (u'title', u'Template:Crew TV')
         entry['title']
         for entry in res['query']['querypage']['results']
     ]
+
+
+def get_portable_infobox_params(site: Site, template_name: str):
+    """
+    Please provide Template namespace suffix in template_name
+
+    :type site Site
+    :type template_name str
+    :rtype: list[str]
+    """
+    logging.info('Getting %s infobox parameters ...', template_name)
+
+    # http://poznan.wikia.com/api.php?action=templateparameters&titles=Szablon:Ulica_infobox&format=json
+    res = site.get(action='templateparameters', titles=template_name)
+
+    if res['pages']:
+        item = next(iter(res['pages'].items()))[1]
+        return item['params']
+
+    return []
 
 
 def get_portable_infoboxes(wikis):
@@ -50,13 +77,19 @@ def get_portable_infoboxes(wikis):
     """
     logger = logging.getLogger('get_portable_infoboxes')
 
+    # on how many wikis a template is used?
     global_templates = Counter()
+
+    # how frequently is a given parameter used in this template across wikis?
+    template_parameters = defaultdict(Counter)
 
     for wiki_domain in wikis:
         site = get_site(wiki_domain)
 
         logger.info('Processing <%s> wiki', site.host[1])
 
+        # fetch all templates as we want to get only the top templates
+        templates = get_querypage(site, 'Mostlinkedtemplates')
         all_infoboxes = get_querypage(site, 'AllInfoboxes')
         non_portable = get_querypage(site, 'Nonportableinfoboxes')
         # print(all_infoboxes, non_portable)
@@ -67,9 +100,16 @@ def get_portable_infoboxes(wikis):
         # list only portable infoboxes
         infoboxes = [
             template
-            for template in all_infoboxes
-            if template not in non_portable
-        ]
+            for template in templates
+            if template in all_infoboxes and template not in non_portable
+        ][:50]
+
+        for infobox in infoboxes:
+            params = get_portable_infobox_params(site, infobox)
+            # print(wiki_domain, infobox, params)
+
+            # update per template params statistics
+            template_parameters[infobox].update(set(params))
 
         # print(wiki_domain, infoboxes)
 
@@ -77,7 +117,12 @@ def get_portable_infoboxes(wikis):
             global_templates.update((infobox,))
 
     logger.info('%d unique template', len(global_templates.keys()))
-    logger.info(global_templates.most_common(10))
+
+    # get info about most common ones
+    for infobox, usage_count in global_templates.most_common(25):
+        logger.info('Most common parameters for %s (used on %d wikis): %s',
+                    infobox, usage_count,
+                    template_parameters[infobox].most_common())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Given a list of wikis provided by @JoannaBorun emits statistics regarding shared templates, their parameters and value types.

This script for each wiki:
* takes 50 most used portable infoboxes
* analyses the names of template parameters


### Results

```
INFO:get_portable_infoboxes:231 unique template
INFO:get_portable_infoboxes:Most common parameters for Template:Episode (used on 5 wikis): [('director', 5), ('writer', 5), ('airdate', 4), ('image', 4), ('season', 3), ('viewers', 3), ('previous', 3), ('next', 3), ('title', 2), ('number', 2), ('guests', 2), ('postdate', 1), ('releasedate', 1), ('cast', 1), ('episodenumber', 1), ('production', 1), ('overallnumber', 1), ('producer', 1), ('episode name', 1), ('narrator', 1), ('next episode', 1), ('air date', 1), ('previous episode', 1), ('director-technical', 1), ('supervising producer', 1), ('supervising director', 1), ('animation supervisor', 1), ('storyboard artist', 1), ('director-storyboard', 1), ('seasonnumber', 1), ('director-creative', 1), ('briefsummary', 1), ('director-animation', 1), ('sisterep', 1), ('episode number', 1)]
INFO:get_portable_infoboxes:Most common parameters for Template:Object (used on 3 wikis): [('image', 3), ('name', 2), ('Title', 1), ('Name', 1), ('Owner', 1), ('Type', 1), ('LatestAppearance', 1), ('OtherAppearances', 1), ('FirstAppearance', 1), ('producer', 1), ('Row 5 title', 1), ('appearance', 1), ('Row 4 info', 1), ('Row 14 info', 1), ('type', 1), ('Row 20 info', 1), ('Row 10 info', 1), ('Row 7 title', 1), ('Row 6 title', 1), ('season', 1), ('designs', 1), ('Row 9 title', 1), ('Row 12 info', 1), ('Row 13 info', 1), ('Row 4 title', 1), ('Row 3 title', 1), ('Row 5 info', 1), ('Row 16 info', 1), ('Row 11 info', 1), ('Row 9 info', 1), ('Row 1 title', 1), ('Row 19 info', 1), ('Row 2 title', 1), ('Row 8 info', 1), ('Row 7 info', 1), ('Row 15 info', 1), ('Row 18 info', 1), ('Row 17 info', 1), ('Row 3 info', 1), ('Row 1 info', 1), ('Row 6 info', 1), ('Row 10 title', 1), ('mentioned', 1), ('latest-appearance', 1), ('Row 8 title', 1), ('caption', 1), ('owner', 1), ('Row 2 info', 1), ('first-appearance', 1), ('usage', 1), ('manufacturer', 1), ('owner(s)', 1), ('made', 1)]
```